### PR TITLE
Add performance quick wins big plan prompt

### DIFF
--- a/prompts/myplanet-daily-bigplanperformancequickwins.md
+++ b/prompts/myplanet-daily-bigplanperformancequickwins.md
@@ -1,0 +1,35 @@
+# myplanet: daily - big plan performance quick wins
+an analysis suggested
+
+Refactor Roadmap (High → Low Priority)
+1. Finish Cleaning the Data Layer
+2. Introduce Global Navigation Architecture
+3. Expand ViewModel and Use Layers
+4. Complete Dependency Injection Cleanup
+5. Consolidate Sync and Upload Workflow
+6. Migrate UI Incrementally to Compose
+7. Optimize Remaining Performance Hotspots
+8. Improve Code Health and Add Tests
+
+based on that tell me all the spots with tasks we should do to accomplish above suggestion
+remember we can only review 9.99ish pr s a round/day
+Mostly we wanna avoid merge conflicts during this PR review merge round
+also this time focus specially on
+performance quick wins
+micro-optimizations that unblock bigger refactors later
+anything that removes obvious inefficiencies without big rewrites
+
+consider though
+di
+data layers  (also use our RealmRepository)
+diffutil / listadapter (also use our DiffUtils.itemCallback)
+viewmodels
+threading / dispatchers usage
+long running observers or listeners
+
+No use cases no jetpack stuff
+we want low hanging fruits
+no complicated stuff with many changes
+so it is easily reviewable
+also do not add unused code
+keep it as granular as possible


### PR DESCRIPTION
## Summary
- add a new myplanet daily prompt focusing on performance quick wins

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb908a61d8832b8e82cd9219fefab8