### PR TITLE
Add view layer dead code audit prompt

### DIFF
--- a/prompts/myplanet-daily-deadcodeviewlayer.md
+++ b/prompts/myplanet-daily-deadcodeviewlayer.md
@@ -1,0 +1,7 @@
+# myplanet: daily - dead code view layer
+Conduct a repository-wide dead-code audit.
+Focus tightly on the view/UI layer (Activities, Fragments, Compose screens, adapters, XML bindings).
+Show stepwise validation (minimum five steps) for each suspect.
+Tell us about the level of logic for confirming or not.
+Assign a “cleanup vs implement” rating (1–100).
+Include removal and revival task stubs with precise path hints.


### PR DESCRIPTION
## Summary
- add a new daily MyPlanet prompt for auditing dead code in the view layer
- highlight validation steps, logic expectations, rating guidance, and task stubs specific to UI components

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb90c567c4832bbd3d79ea859ea91b