### PR TITLE
Adjust sidebar spacing and metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,12 +26,12 @@
     #list { max-height: 70vh; overflow: auto; padding-right: 4px; }
     #list ul { list-style: none; margin: 0; padding-left: 16px; }
     #list > ul { padding-left: 0; }
-    .tree-dir { display: flex; align-items: center; gap: 6px; padding: 8px 10px; border-radius: 10px; cursor: pointer; color: var(--text); }
+    .tree-dir { display: flex; align-items: center; gap: 6px; padding: 6px 10px; border-radius: 10px; cursor: pointer; color: var(--text); }
     .tree-dir:hover { background: #141936; }
     .tree-dir button { appearance: none; border: none; background: none; color: var(--muted); cursor: pointer; font-size: 12px; display: flex; align-items: center; justify-content: center; width: 18px; }
     .tree-dir button:focus { outline: 1px solid var(--accent); border-radius: 4px; }
     .tree-dir .folder-name { font-size: 13px; font-weight: 600; }
-    .item { display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 10px 12px; border-radius: 10px; border: 1px solid transparent; background: #12162a; cursor: pointer; }
+    .item { display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 6px 10px; border-radius: 10px; border: 1px solid transparent; background: #12162a; cursor: pointer; }
     .item:hover { border-color: var(--border); background: #141936; }
     .item-title { font-size: 14px; font-weight: 600; }
     .item-meta { color: var(--muted); font-size: 12px; }
@@ -425,11 +425,7 @@
           const t = document.createElement('div');
           t.className = 'item-title';
           t.textContent = prettyTitle(file.name);
-          const m = document.createElement('div');
-          m.className = 'item-meta';
-          m.textContent = file.path.replace(/^prompts\//, '');
           left.appendChild(t);
-          left.appendChild(m);
           a.appendChild(left);
           li.appendChild(a);
           container.appendChild(li);


### PR DESCRIPTION
## Summary
- reduce sidebar folder and file padding to align rows
- remove the sidebar path metadata so items only show their titles

## Testing
- python -m http.server 8000 (manual verification in browser)


------
https://chatgpt.com/codex/tasks/task_e_68d046e1e274832b9ec6cfc243b9a12a