### PR TITLE
Add repository boundaries daily bigplan prompt

### DIFF
--- a/prompts/myplanet/daily/bigplan/13-repository-boundaries.md
+++ b/prompts/myplanet/daily/bigplan/13-repository-boundaries.md
@@ -1,4 +1,4 @@
-an analysis suggested
+# Daily Big Plan Prompt
 
 Refactor Roadmap (High → Low Priority)
 1. Finish Cleaning the Data Layer

--- a/prompts/myplanet/daily/bigplan/13-repository-boundaries.md
+++ b/prompts/myplanet/daily/bigplan/13-repository-boundaries.md
@@ -1,0 +1,31 @@
+an analysis suggested
+
+Refactor Roadmap (High → Low Priority)
+1. Finish Cleaning the Data Layer
+2. Introduce Global Navigation Architecture
+3. Expand ViewModel and Use Layers
+4. Complete Dependency Injection Cleanup
+5. Consolidate Sync and Upload Workflow
+6. Migrate UI Incrementally to Compose
+7. Optimize Remaining Performance Hotspots
+8. Improve Code Health and Add Tests
+
+based on that tell me all the spots with tasks we should do to accomplish above suggestion
+remember we can only review 9.99ish pr s a round/day
+Mostly we wanna avoid merge conflicts during this PR review merge round
+also this time focus specially on
+reinforcing repository boundaries between layers
+call out cross-feature data leaks and tighten repository interfaces
+
+consider though
+di
+data layers  (also use our RealmRepository)
+diffutil / listadapter (also use our DiffUtils.itemCallback)
+viewmodels
+
+No use cases no jetpack stuff
+we want low hanging fruits
+no complicated stuff with many changes
+so it is easily reviewable
+also do not add unused code
+keep it as granular as possible


### PR DESCRIPTION
## Summary
- add the day 13 daily bigplan prompt focusing on repository boundaries
- emphasize tightening cross-feature data access while keeping existing guidance consistent

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d0501fc2fc832b837ac60553525610