### PR TITLE
Support gist pointer prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,22 @@ prompt-sharing/
 
 4. After a minute or two, the live site will auto-refresh to include your new prompt.
 
+### Using a Gist pointer
+
+Instead of storing the full prompt in this repo, you can point a prompt file at a GitHub Gist. To do this, create a markdown file whose entire body is the raw Gist URL:
+
+```markdown
+https://gist.githubusercontent.com/your-username/abc123456789/raw/my-shared-prompt.md
+```
+
+When the site loads this file it will fetch the referenced Gist content, cache it, and render that content in place of the URL.
+
+**Limitations**
+
+* The URL must be a publicly readable `gist.githubusercontent.com` raw link. Private gists or GitHub pages that require auth are not supported.
+* Only a single URL is supported in the file body; any extra text will be treated as a normal prompt rather than a pointer.
+* Updates to the Gist will appear the next time the site fetches that URL. If you change the pointer to a different Gist, update the URL in the prompt file.
+
 ## Linking to prompts
 
 Every prompt has its own URL:

--- a/index.html
+++ b/index.html
@@ -134,7 +134,7 @@
 
     // ---------- Runtime state ----------
     let files = [];           // [{name, path, download_url, sha}, ...]
-    let cacheRaw = new Map(); // slug -> raw markdown text
+    let cacheRaw = new Map(); // slug -> raw markdown text (or object for gist pointers)
     let currentSlug = null;   // currently selected slug
     let expandedState = new Set();
     let expandedStateKey = null;
@@ -156,6 +156,25 @@
     // ---------- Helpers ----------
     const rawURL = (path) =>
       `https://raw.githubusercontent.com/${currentOwner}/${currentRepo}/${currentBranch}/${path}`;
+
+    const GIST_POINTER_REGEX = /^https:\/\/gist\.githubusercontent\.com\/\S+\/raw\/\S+$/i;
+
+    async function fetchGistContent(gistUrl) {
+      const cacheKey = `gist:${gistUrl}`;
+      if (cacheRaw.has(cacheKey)) {
+        return cacheRaw.get(cacheKey);
+      }
+      const url = gistUrl.includes('?')
+        ? `${gistUrl}&ts=${Date.now()}`
+        : `${gistUrl}?ts=${Date.now()}`;
+      const res = await fetch(url, { cache: 'no-store' });
+      if (!res.ok) {
+        throw new Error(`Gist fetch failed: ${res.status} ${res.statusText}`);
+      }
+      const text = await res.text();
+      cacheRaw.set(cacheKey, text);
+      return text;
+    }
 
     function slugify(filePath) {
       const base = filePath.replace(/\.md$/i, '').toLowerCase().replace(/\s+/g, '-');
@@ -507,11 +526,44 @@
         updateActiveItem();
       }
 
-      let raw = cacheRaw.get(slug);
-      if (!raw) {
+      let cached = cacheRaw.get(slug);
+      let raw;
+      if (cached) {
+        if (typeof cached === 'string') {
+          raw = cached;
+        } else {
+          const { gistUrl } = cached;
+          if (gistUrl) {
+            try {
+              const gistBody = await fetchGistContent(gistUrl);
+              raw = gistBody;
+              cached.body = gistBody;
+            } catch (err) {
+              console.error(err);
+              raw = cached.body || gistUrl;
+            }
+          } else {
+            raw = cached.body;
+          }
+        }
+      } else {
         const res = await fetch(rawURL(f.path) + `?ts=${Date.now()}`, { cache: 'no-store' });
-        raw = await res.text();
-        cacheRaw.set(slug, raw);
+        let text = await res.text();
+        const trimmed = text.trim();
+        if (GIST_POINTER_REGEX.test(trimmed)) {
+          try {
+            const gistBody = await fetchGistContent(trimmed);
+            raw = gistBody;
+            cacheRaw.set(slug, { body: gistBody, gistUrl: trimmed });
+          } catch (err) {
+            console.error(err);
+            raw = text;
+            cacheRaw.set(slug, { body: text, gistUrl: trimmed });
+          }
+        } else {
+          raw = text;
+          cacheRaw.set(slug, raw);
+        }
       }
       copyBtn.onclick = async () => {
         try {


### PR DESCRIPTION
## Summary
- detect gist raw URL pointers in prompt markdown and load the referenced content before rendering
- cache gist payloads by slug and URL to avoid duplicate fetches
- document the gist pointer convention and its limitations in the README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf8e20004c832bbd1f32166ec2bdbb