### PR TITLE
smoother header link fixes #18)

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,7 +60,9 @@
     <div class="wrap" style="padding:0;grid-template-columns:1fr;gap:0">
       <div style="display:flex; align-items:center; justify-content:space-between; gap:12px;">
         <div>
-          <div style="font-size:18px; font-weight:800; letter-spacing:0.2px;">OLE Prompt Library</div>
+          <a href="https://ole-vi.github.io/prompt-sharing/" style="text-decoration:none; color:inherit;">
+            <div style="font-size:18px; font-weight:800; letter-spacing:0.2px;">OLE Prompt Library</div>
+          </a>
           <div style="color:var(--muted); font-size:13px;">Single file, no build. Drop .md files in <code>/prompts</code> and they show up here.</div>
         </div>
         <div style="display:flex; align-items:center; gap:8px;">


### PR DESCRIPTION
This now links back to the home page

<img width="678" height="117" alt="image" src="https://github.com/user-attachments/assets/eb88862b-8fcf-4488-99fc-db03b7572e25" />
