### PR TITLE
added special handling for gists (fixes #22)

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,6 +160,45 @@
       `https://raw.githubusercontent.com/${currentOwner}/${currentRepo}/${currentBranch}/${path}`;
 
     const GIST_POINTER_REGEX = /^https:\/\/gist\.githubusercontent\.com\/\S+\/raw\/\S+$/i;
+    const GIST_URL_REGEX = /^https:\/\/gist\.github\.com\/[\w-]+\/[a-f0-9]+\/?(?:#file-[\w.-]+)?(?:\?file=[\w.-]+)?$/i;
+
+    async function resolveGistRawUrl(gistUrl) {
+      // If it's already a raw URL, use it directly
+      if (GIST_POINTER_REGEX.test(gistUrl)) {
+        return gistUrl;
+      }
+
+      // Parse regular gist URLs
+      const match = gistUrl.match(/^https:\/\/gist\.github\.com\/([\w-]+)\/([a-f0-9]+)\/?(?:#file-([\w.-]+))?(?:\?file=([\w.-]+))?$/i);
+      if (!match) {
+        throw new Error('Invalid gist URL format');
+      }
+
+      const [, user, gistId, fragmentFile, queryFile] = match;
+      const targetFile = fragmentFile || queryFile;
+
+      if (targetFile) {
+        // Specific file requested
+        return `https://gist.githubusercontent.com/${user}/${gistId}/raw/${targetFile}`;
+      } else {
+        // No specific file - fetch gist metadata to find the best file
+        const apiUrl = `https://api.github.com/gists/${gistId}`;
+        const res = await fetch(apiUrl);
+        if (!res.ok) {
+          throw new Error(`Failed to fetch gist metadata: ${res.status}`);
+        }
+        const gistData = await res.json();
+        const files = Object.keys(gistData.files);
+        
+        let bestFile = files.find(f => f.endsWith('.md')) || files[0];
+        
+        if (!bestFile) {
+          throw new Error('No files found in gist');
+        }
+        
+        return `https://gist.githubusercontent.com/${user}/${gistId}/raw/${bestFile}`;
+      }
+    }
 
     async function fetchGistContent(gistUrl) {
       const cacheKey = `gist:${gistUrl}`;
@@ -517,10 +556,6 @@
       actionsEl.style.display = 'flex';
       titleEl.textContent = prettyTitle(f.name);
       metaEl.textContent = `File: ${f.path}`;
-      rawBtn.href = rawURL(f.path);
-      ghBtn.href  = `https://github.com/${currentOwner}/${currentRepo}/blob/${currentBranch}/${f.path}`;
-      editBtn.style.display = '';
-      editBtn.href = `https://github.com/${currentOwner}/${currentRepo}/edit/${currentBranch}/${f.path}`;
       const slug = slugify(f.path);
       if (pushHash) history.pushState(null, '', `#p=${encodeURIComponent(slug)}`);
       currentSlug = slug;
@@ -534,45 +569,92 @@
 
       let cached = cacheRaw.get(slug);
       let raw;
+      let isGistContent = false;
+      let gistUrl = null;
+
       if (cached) {
+        console.log('Using cached content:', typeof cached, cached);
         if (typeof cached === 'string') {
           raw = cached;
         } else {
-          const { gistUrl } = cached;
-          if (gistUrl) {
+          // Handle object cache (contains gist info)
+          if (cached.gistUrl) {
+            isGistContent = true;
+            gistUrl = cached.gistUrl;
+            console.log('Cache contains gist URL, refetching...');
             try {
-              const gistBody = await fetchGistContent(gistUrl);
+              // Use the resolved raw URL if available, otherwise resolve again
+              const finalRawUrl = cached.rawGistUrl || await resolveGistRawUrl(cached.gistUrl);
+              console.log('Using raw URL:', finalRawUrl);
+              const gistBody = await fetchGistContent(finalRawUrl);
+              console.log('Refetched gist content length:', gistBody.length);
               raw = gistBody;
               cached.body = gistBody;
+              cached.rawGistUrl = finalRawUrl;
             } catch (err) {
-              console.error(err);
-              raw = cached.body || gistUrl;
+              console.error('Failed to refetch gist:', err);
+              raw = cached.body || `Error loading gist: ${err.message}`;
             }
           } else {
-            raw = cached.body;
+            raw = cached.body || cached;
           }
         }
       } else {
         const res = await fetch(rawURL(f.path) + `?ts=${Date.now()}`, { cache: 'no-store' });
         let text = await res.text();
         const trimmed = text.trim();
-        if (GIST_POINTER_REGEX.test(trimmed)) {
+        
+        // Check for any type of gist URL
+        if (GIST_POINTER_REGEX.test(trimmed) || GIST_URL_REGEX.test(trimmed)) {
+          isGistContent = true;
+          gistUrl = trimmed;
+          console.log('Detected gist URL:', trimmed);
           try {
-            const gistBody = await fetchGistContent(trimmed);
+            const rawGistUrl = await resolveGistRawUrl(trimmed);
+            console.log('Resolved to raw URL:', rawGistUrl);
+            const gistBody = await fetchGistContent(rawGistUrl);
+            console.log('Fetched gist content length:', gistBody.length);
             raw = gistBody;
-            cacheRaw.set(slug, { body: gistBody, gistUrl: trimmed });
+            cacheRaw.set(slug, { body: gistBody, gistUrl: trimmed, rawGistUrl });
           } catch (err) {
-            console.error(err);
+            console.error('Failed to fetch gist:', err);
             raw = text;
-            cacheRaw.set(slug, { body: text, gistUrl: trimmed });
+            cacheRaw.set(slug, { body: text, gistUrl: trimmed, error: err.message });
           }
         } else {
+          console.log('Not a gist URL, using original text');
           raw = text;
           cacheRaw.set(slug, raw);
         }
       }
+
+      // Set buttons based on content type
+      if (isGistContent && gistUrl) {
+        editBtn.textContent = '✏️ Edit Link';
+        editBtn.title = 'Edit the gist link';
+        ghBtn.textContent = '🗂️ View on Gist';
+        ghBtn.title = 'Open the gist on GitHub';
+        ghBtn.href = gistUrl;
+        // For gists, create a data URL with the raw content
+        const blob = new Blob([raw], { type: 'text/plain' });
+        const dataUrl = URL.createObjectURL(blob);
+        rawBtn.href = dataUrl;
+        rawBtn.removeAttribute('download');
+        rawBtn.title = 'Open gist content in new tab';
+      } else {
+        editBtn.textContent = '✏️ Edit on GitHub';
+        editBtn.title = 'Edit the file on GitHub';
+        ghBtn.textContent = '🗂️ View on GitHub';
+        ghBtn.title = 'Open the file on GitHub';
+        ghBtn.href = `https://github.com/${currentOwner}/${currentRepo}/blob/${currentBranch}/${f.path}`;
+        rawBtn.href = rawURL(f.path);
+        rawBtn.title = 'Open raw markdown';
+      }
+      editBtn.style.display = '';
+      editBtn.href = `https://github.com/${currentOwner}/${currentRepo}/edit/${currentBranch}/${f.path}`;
       copyBtn.onclick = async () => {
         try {
+          console.log('Copying content:', raw.substring(0, 100) + (raw.length > 100 ? '...' : ''));
           await navigator.clipboard.writeText(raw);
           copyBtn.textContent = 'Copied';
           setTimeout(() => copyBtn.textContent = '📋 Copy prompt', 1000);
@@ -596,7 +678,21 @@
         titleEl.textContent = firstLine.replace(/^#\s+/, '');
       }
 
-      contentEl.innerHTML = marked.parse(raw, { breaks: true });
+      // Check if this content came from a gist for rendering
+      if (isGistContent) {
+        // For gist content, if it doesn't look like markdown, wrap it in a code block
+        const looksLikeMarkdown = /^#|^\*|^-|^\d+\.|```/.test(raw.trim());
+        if (!looksLikeMarkdown) {
+          // Wrap in a code block for better display
+          const wrappedContent = '```\n' + raw + '\n```';
+          contentEl.innerHTML = marked.parse(wrappedContent, { breaks: true });
+        } else {
+          contentEl.innerHTML = marked.parse(raw, { breaks: true });
+        }
+      } else {
+        contentEl.innerHTML = marked.parse(raw, { breaks: true });
+      }
+      
       enhanceCodeBlocks();
     }
 

--- a/index.html
+++ b/index.html
@@ -106,13 +106,10 @@
   </footer>
 
   <script>
-    // ---------- DEFAULT CONFIG ----------
     const OWNER  = "ole-vi";
     const REPO   = "prompt-sharing";
     const BRANCH = "main";
     const PRETTY_TITLES = true;
-
-    // ---------- DYNAMIC OVERRIDES FROM URL ----------
     function parseParams() {
       const out = {};
       const sources = [
@@ -133,10 +130,9 @@
     let currentRepo   = params.repo   || REPO;
     let currentBranch = params.branch || BRANCH;
 
-    // ---------- Runtime state ----------
-    let files = [];           // [{name, path, download_url, sha}, ...]
-    let cacheRaw = new Map(); // slug -> raw markdown text (or object for gist pointers)
-    let currentSlug = null;   // currently selected slug
+    let files = [];
+    let cacheRaw = new Map();
+    let currentSlug = null;
     let expandedState = new Set();
     let expandedStateKey = null;
 
@@ -155,7 +151,6 @@
     const repoPill = document.getElementById('repoPill');
     const branchSelect = document.getElementById('branchSelect');
 
-    // ---------- Helpers ----------
     const rawURL = (path) =>
       `https://raw.githubusercontent.com/${currentOwner}/${currentRepo}/${currentBranch}/${path}`;
 
@@ -261,7 +256,6 @@
       return addEmoji(base.replace(/[-_]/g, " "));
     }
 
-    // ---------- Robust GitHub fetch + fallbacks ----------
     async function fetchJSON(url) {
       const res = await fetch(url, {
         cache: 'no-store',
@@ -311,14 +305,12 @@
       }));
     }
 
-    // ---------- Load + render list (with session cache) ----------
     async function refreshList(cacheKey) {
       let data;
       try {
         data = await listPromptsViaContents();
       } catch (e) {
         if (e.status === 403 || e.status === 404) {
-          // Rate limited or directory missing → fallback to Trees API
           data = await listPromptsViaTrees();
         } else {
           throw e;
@@ -334,20 +326,16 @@
       const cacheKey = `prompts:${currentOwner}/${currentRepo}@${currentBranch}`;
 
       try {
-        // Use session cache if present
         const cached = sessionStorage.getItem(cacheKey);
         if (cached) {
           files = JSON.parse(cached);
           renderList(files);
-          // Background refresh (non-blocking)
           refreshList(cacheKey).catch(() => {});
-          // Deep link handling
           const match = location.hash.match(/[#&?]p=([^&]+)/) || location.hash.match(/^#([^&]+)$/);
           if (match) selectBySlug(decodeURIComponent(match[1]));
           return;
         }
 
-        // First load (no cache)
         await refreshList(cacheKey);
         const match = location.hash.match(/[#&?]p=([^&]+)/) || location.hash.match(/^#([^&]+)$/);
         if (match) selectBySlug(decodeURIComponent(match[1]));
@@ -577,13 +565,11 @@
         if (typeof cached === 'string') {
           raw = cached;
         } else {
-          // Handle object cache (contains gist info)
           if (cached.gistUrl) {
             isGistContent = true;
             gistUrl = cached.gistUrl;
             console.log('Cache contains gist URL, refetching...');
             try {
-              // Use the resolved raw URL if available, otherwise resolve again
               const finalRawUrl = cached.rawGistUrl || await resolveGistRawUrl(cached.gistUrl);
               console.log('Using raw URL:', finalRawUrl);
               const gistBody = await fetchGistContent(finalRawUrl);
@@ -604,7 +590,6 @@
         let text = await res.text();
         const trimmed = text.trim();
         
-        // Check for any type of gist URL
         if (GIST_POINTER_REGEX.test(trimmed) || GIST_URL_REGEX.test(trimmed)) {
           isGistContent = true;
           gistUrl = trimmed;
@@ -628,14 +613,12 @@
         }
       }
 
-      // Set buttons based on content type
       if (isGistContent && gistUrl) {
         editBtn.textContent = '✏️ Edit Link';
         editBtn.title = 'Edit the gist link';
         ghBtn.textContent = '🗂️ View on Gist';
         ghBtn.title = 'Open the gist on GitHub';
         ghBtn.href = gistUrl;
-        // For gists, create a data URL with the raw content
         const blob = new Blob([raw], { type: 'text/plain' });
         const dataUrl = URL.createObjectURL(blob);
         rawBtn.href = dataUrl;
@@ -678,12 +661,9 @@
         titleEl.textContent = firstLine.replace(/^#\s+/, '');
       }
 
-      // Check if this content came from a gist for rendering
       if (isGistContent) {
-        // For gist content, if it doesn't look like markdown, wrap it in a code block
         const looksLikeMarkdown = /^#|^\*|^-|^\d+\.|```/.test(raw.trim());
         if (!looksLikeMarkdown) {
-          // Wrap in a code block for better display
           const wrappedContent = '```\n' + raw + '\n```';
           contentEl.innerHTML = marked.parse(wrappedContent, { breaks: true });
         } else {
@@ -723,7 +703,6 @@
       });
     }
 
-    // --- Branch dropdown: fetch & populate ---
     async function loadBranches() {
       branchSelect.disabled = true;
       branchSelect.innerHTML = `<option>Loading branches…</option>`;
@@ -761,7 +740,6 @@
       }
     }
 
-    // Handle dropdown changes
     document.addEventListener('change', (e) => {
       if (e.target !== branchSelect) return;
       currentBranch = branchSelect.value;
@@ -779,7 +757,6 @@
       loadList();
     });
 
-    // Respond to hash/query changes (owner/repo/branch via URL)
     window.addEventListener('hashchange', () => {
       const p = parseParams();
       const prev = { owner: currentOwner, repo: currentRepo, branch: currentBranch };
@@ -820,7 +797,6 @@
       renderList(files);
     });
 
-    // Kick off
     loadList();
     loadBranches();
   </script>


### PR DESCRIPTION
Gists now render the body:

<img width="1767" height="1041" alt="image" src="https://github.com/user-attachments/assets/efc8f808-1566-461a-9e65-7682a497c951" />

- Copy prompt - copies the gist body
- Copy link - copies link to the gist
- Edit link - edits the link to the gist (what is stored in the prompt-library repo)
- View on Gist - opens the link the the gist
- Open raw - opens the body of the gist in a new tab as raw code (similar to how other prompts are handled)
